### PR TITLE
Improve resize & remove number of headers limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/hpack/strqueue
 src/hpack/hcollections
 tests/tests
 tests/sometests
+bin

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Based on [rfc7541](https://tools.ietf.org/html/rfc7541).
 
 ## Compatibility
 
-> nim >= 0.19
+> Nim +2
 
 ## Install
 
@@ -35,7 +35,7 @@ let req1 = @[
   0x8286'u16, 0x8441, 0x8cf1, 0xe3c2,
   0xe5f2, 0x3a6b, 0xa0ab, 0x90f4].toBytes
 var ds = initDecodedStr()
-var dh = initDynHeaders(256, 16)
+var dh = initDynHeaders(256)
 assert hdecodeAll(req1, dh, ds) == req1.len
 assert($ds ==
   ":method: GET\r\L" &
@@ -72,7 +72,7 @@ proc toBytes(s: seq[uint16]): seq[byte] =
 
 # First response
 var resp = newSeq[byte]()
-var dh = initDynHeaders(256, 16)
+var dh = initDynHeaders(256)
 hencode(":method", "GET", dh, resp)
 hencode(":scheme", "http", dh, resp)
 hencode(":path", "/", dh, resp)

--- a/hpack.nimble
+++ b/hpack.nimble
@@ -13,6 +13,7 @@ task gen, "Gen data":
   exec "nim c -r gen/huffman.nim"
 
 task test, "Test":
+  exec "nim c -r -o:bin/hpack src/hpack.nim"
   exec "nim c -r src/hpack/hcollections.nim"
   exec "nim c -r src/hpack/encoder.nim"
   exec "nim c -r src/hpack/huffman_encoder.nim"

--- a/src/hpack.nim
+++ b/src/hpack.nim
@@ -2,9 +2,9 @@
 ## HPACK (Header Compression for HTTP/2)
 
 import
-  hpack/encoder,
-  hpack/decoder,
-  hpack/hcollections
+  ./hpack/encoder,
+  ./hpack/decoder,
+  ./hpack/hcollections
 
 export
   encoder,

--- a/src/hpack/decoder.nim
+++ b/src/hpack/decoder.nim
@@ -282,8 +282,11 @@ proc hdecode*(
     result = litdecode(s, h, d, 4, false)
     return
   # dyn table size update
+  # https://www.rfc-editor.org/rfc/rfc7541.html#section-6.3
   if s[0] shr 5 == 1:
     result = intdecode(s, 5, dhSize)
+    if dhSize > h.maxSize:
+      raiseDecodeError("dyn table size update exceeds the max size")
     return
   raiseDecodeError("unknown octet prefix")
 

--- a/src/hpack/decoder.nim
+++ b/src/hpack/decoder.nim
@@ -325,7 +325,7 @@ proc hdecodeAll*(
   while i < s.len:
     inc(i, hdecode(toOpenArray(s, i, s.len-1), h, d, dhSize))
     if dhSize > -1:
-      h.setLen dhSize
+      h.setSize dhSize
   assert i == s.len
 
 when isMainModule:

--- a/src/hpack/decoder.nim
+++ b/src/hpack/decoder.nim
@@ -325,7 +325,7 @@ proc hdecodeAll*(
   while i < s.len:
     inc(i, hdecode(toOpenArray(s, i, s.len-1), h, d, dhSize))
     if dhSize > -1:
-      h.resize dhSize
+      h.setLen dhSize
   assert i == s.len
 
 when isMainModule:

--- a/src/hpack/decoder.nim
+++ b/src/hpack/decoder.nim
@@ -305,28 +305,28 @@ proc hdecodeAll*(
     h: var DynHeaders,
     d: var DecodedStr,
     dhSize: var int)
-    {.raises: [DynHeadersError, DecodeError].} =
-  ## Decode all headers from the blob of bytes
-  ## ``s`` and stores it into a decoded string``d``.
-  ## The dynamic headers are stored into ``h``
-  ## to decode the next message.
-  ## The dynamic table size update is stored
-  ## into ``dhSize``, default to ``-1``
-  ## if there's no update
+    {.deprecated, raises: [DynHeadersError, DecodeError].} =
   var i = 0
   while i < s.len:
     inc(i, hdecode(toOpenArray(s, i, s.len-1), h, d, dhSize))
   assert i == s.len
 
 proc hdecodeAll*(
-    s: openArray[byte],
-    h: var DynHeaders,
-    d: var DecodedStr)
-    {.deprecated, raises: [DynHeadersError, DecodeError].} =
-  ## Deprecated, use ``hdecodeAll(openArray[byte],
-  ## var DynHeaders, var DecodedStr, var int)`` instead
+  s: openArray[byte],
+  h: var DynHeaders,
+  d: var DecodedStr
+) {.raises: [DynHeadersError, DecodeError].} =
+  ## Decode all headers from the blob of bytes
+  ## ``s`` and stores it into a decoded string``d``.
+  ## The dynamic headers are stored into ``h``
+  ## to decode the next message.
   var dhSize = 0
-  hdecodeAll(s, h, d, dhSize)
+  var i = 0
+  while i < s.len:
+    inc(i, hdecode(toOpenArray(s, i, s.len-1), h, d, dhSize))
+    if dhSize > -1:
+      h.resize dhSize
+  assert i == s.len
 
 when isMainModule:
   block:

--- a/src/hpack/encoder.nim
+++ b/src/hpack/encoder.nim
@@ -160,17 +160,18 @@ proc signalDynTableSizeUpdate*(
   ## field to the seq of bytes
   result = intencode(size, 5, s)
 
-func applyDynTableSizeUpdates*(
+func encodeLastResize*(
   dh: var DynHeaders,
   s: var seq[byte]
 ): Natural {.discardable, raises: [].} =
+  ## Add last dynamic table resize signal
+  ## to ``s``
   doAssert dh.minResize <= dh.finalResize
   result = 0
-  if dh.minResize != dh.initialSize:
+  if dh.hasResized():
     result += signalDynTableSizeUpdate(s, dh.minResize)
   if dh.finalResize != dh.minResize:
     result += signalDynTableSizeUpdate(s, dh.finalResize)
-  dh.resetResize()
 
 when isMainModule:
   import decoder

--- a/src/hpack/encoder.nim
+++ b/src/hpack/encoder.nim
@@ -166,12 +166,12 @@ func encodeLastResize*(
 ): Natural {.discardable, raises: [].} =
   ## Add last dynamic table resize signal
   ## to ``s``
-  doAssert dh.minResize <= dh.finalResize
+  doAssert dh.minSetLen <= dh.finalSetLen
   result = 0
   if dh.hasResized():
-    result += signalDynTableSizeUpdate(s, dh.minResize)
-  if dh.finalResize != dh.minResize:
-    result += signalDynTableSizeUpdate(s, dh.finalResize)
+    result += signalDynTableSizeUpdate(s, dh.minSetLen)
+  if dh.finalSetLen != dh.minSetLen:
+    result += signalDynTableSizeUpdate(s, dh.finalSetLen)
 
 when isMainModule:
   import decoder

--- a/src/hpack/encoder.nim
+++ b/src/hpack/encoder.nim
@@ -24,17 +24,17 @@ proc intencode(x: Natural, n: NbitPref, s: var seq[byte]): int {.inline.} =
   # todo: add option to not set 2^N bit
   result = 1
   if x.uint < n.ones:
-    s.add(cast[uint8](x) or (1'u8 shl n))
+    s.add(x.uint8 or (1'u8 shl n))
     return
   s.add(n.ones or (1'u8 shl n))
   var x = x.uint - n.ones
   var i = 0
   # leading 1-bit means continuation
   while x > 7.ones.uint:
-    s.add(cast[uint8](x and 7.ones) or 1'u8 shl 7)
+    s.add((x and 7.ones).uint8 or 1'u8 shl 7)
     x = x shr 7
     inc result
-  s.add(cast[uint8](x))
+  s.add x.uint8
   inc result
 
 proc strencode(

--- a/src/hpack/encoder.nim
+++ b/src/hpack/encoder.nim
@@ -166,12 +166,12 @@ func encodeLastResize*(
 ): Natural {.discardable, raises: [].} =
   ## Add last dynamic table resize signal
   ## to ``s``
-  doAssert dh.minSetLen <= dh.finalSetLen
+  doAssert dh.minSetSize <= dh.finalSetSize
   result = 0
   if dh.hasResized():
-    result += signalDynTableSizeUpdate(s, dh.minSetLen)
-  if dh.finalSetLen != dh.minSetLen:
-    result += signalDynTableSizeUpdate(s, dh.finalSetLen)
+    result += signalDynTableSizeUpdate(s, dh.minSetSize)
+  if dh.finalSetSize != dh.minSetSize:
+    result += signalDynTableSizeUpdate(s, dh.finalSetSize)
 
 when isMainModule:
   import decoder

--- a/src/hpack/hcollections.nim
+++ b/src/hpack/hcollections.nim
@@ -212,16 +212,18 @@ proc cmp*(
     #s.toOpenArray(0, mLen-1) == q.s.toOpenArray(b.a, b.a+mLen-1) and
     #s.toOpenArray(mLen, b.len-1) == q.s.toOpenArray(0, b.len-mLen-1)
 
-func initialSize*(q: DynHeaders): int =
-  q.initialSize
-
 func minResize*(q: DynHeaders): int =
   q.minResize
 
 func finalResize*(q: DynHeaders): int =
   q.finalResize
 
-func resetResize*(q: var DynHeaders) =
+func hasResized*(dh: DynHeaders): bool =
+  result =
+    dh.initialSize != dh.minResize or
+    dh.minResize != dh.finalResize
+
+func clearLastResize*(q: var DynHeaders) =
   q.minResize = q.finalResize
   q.initialSize = q.finalResize
 

--- a/src/hpack/hcollections.nim
+++ b/src/hpack/hcollections.nim
@@ -1,9 +1,7 @@
 ## Dynamic headers table
 
-from math import isPowerOfTwo
-
-import
-  exceptions
+import std/deques
+import ./exceptions
 
 export
   exceptions
@@ -43,74 +41,60 @@ proc initHBounds*(n, v: Slice[int]): HBounds {.inline.} =
   ## header's name and value
   HBounds(n: n, v: v)
 
-# todo: HPACK does not know about the qsize limit,
-#       so raise an exception when there is no more room available
 type
   DynHeaders* = object
     ## A circular queue.
     ## This is an implementaion of the
-    ## dynamic header table. It has both
-    ## total length of headers and
-    ## number of headers limits.
+    ## dynamic header table.
     ## It can be efficiently reused.
     ## ``HBounds`` ends may be out of bounds and
     ## need to be wrapped around. All
     ## functions here take care of that
     s: string
     pos, filled: int
-    b: seq[HBounds]
-    head, tail, length: int
-    maxSize*, initialSize, minResize, finalResize: int
+    bounds: Deque[HBounds]
+    maxSize*, initialSize, minSetLen, finalSetLen: int
 
-proc initDynHeaders*(strsize, qsize: Natural): DynHeaders {.inline.} =
+proc initDynHeaders*(strsize: int): DynHeaders {.inline.} =
   ## Initialize a dynamic headers table.
   ## ``strsize`` is the max size in bytes
   ## of all headers put together.
-  ## It must be greater than 32,
-  ## since each header has 32 bytes
-  ## of overhead according to spec.
-  ## Queue size must be a power of two.
-  assert strsize > 32
-  assert qsize.isPowerOfTwo
   DynHeaders(
     s: newString(strsize),
     pos: 0,
     filled: 0,
-    b: newSeq[HBounds](qsize),
-    head: qsize-1,
-    tail: 0,
-    length: 0,
+    bounds: initDeque[HBounds](),
     maxSize: strsize,
     initialSize: strsize,
-    minReSize: strsize,
-    finalResize: strsize)
+    minSetLen: strsize,
+    finalSetLen: strsize)
 
 proc len*(q: DynHeaders): int {.inline.} =
-  ## Number of headers
-  q.length
+  q.bounds.len
 
 proc clear*(q: var DynHeaders) {.inline.} =
   ## Efficiently clear the table
-  q.head = q.b.len-1
   q.pos = 0
   q.filled = 0
-  q.tail = 0
-  q.length = 0
+  q.bounds.clear()
+  q.minSetLen = 0
+  q.finalSetLen = 0
 
 proc reset*(q: var DynHeaders) {.deprecated.} =
   ## Deprecated, use ``clear()`` instead
   q.clear()
 
 proc `[]`*(q: DynHeaders, i: Natural): HBounds {.inline.} =
-  ## Return header bounds at position ``i``
-  assert i < q.len, "out of bounds"
-  q.b[(q.tail+q.len-1-i) and (q.b.len-1)]
+  q.bounds[i]
 
 template a(hb: HBounds): int =
   hb.n.a
 
 template b(hb: HBounds): int =
   hb.v.b
+
+template len(hb: HBounds): int =
+  hb.n.len+hb.v.len
 
 proc left(q: DynHeaders): Natural {.inline.} =
   ## Return available space
@@ -119,12 +103,10 @@ proc left(q: DynHeaders): Natural {.inline.} =
 proc pop(q: var DynHeaders): HBounds {.inline.} =
   ## Return and remove header
   ## from the table in FIFO order
-  assert q.len > 0, "empty queue"
-  result = q.b[q.tail]
-  q.tail = (q.tail+1) and (q.b.len-1)
-  dec q.length
-  dec(q.filled, result.b-result.a+1+32)
-  assert q.filled >= 0
+  doAssert q.len > 0, "empty queue"
+  result = q.bounds.popLast()
+  dec(q.filled, result.len+32)
+  doAssert q.filled >= 0
 
 proc add*(q: var DynHeaders, n, v: openArray[char]) {.inline.} =
   ## Add a header name and value to the table.
@@ -134,12 +116,11 @@ proc add*(q: var DynHeaders, n, v: openArray[char]) {.inline.} =
   while q.len > 0 and nvLen > q.left-32:
     discard q.pop()
   if nvLen > q.s.len-32:
-    raise newException(DynHeadersError, "string too long")
-  q.head = (q.head+1) and (q.b.len-1)
-  q.b[q.head] = HBounds(
+    return
+  q.bounds.addFirst HBounds(
     n: q.pos .. q.pos+n.len-1,
-    v: q.pos+n.len .. q.pos+nvLen-1)
-  q.length = min(q.b.len, q.length+1)
+    v: q.pos+n.len .. q.pos+nvLen-1
+  )
   let nLen = min(n.len, q.s.len-q.pos)
   strcopy(q.s, n, q.pos, 0, nLen)
   strcopy(q.s, n, 0, nLen, n.len-nLen)
@@ -149,33 +130,25 @@ proc add*(q: var DynHeaders, n, v: openArray[char]) {.inline.} =
   strcopy(q.s, v, 0, vLen, v.len-vLen)
   q.pos = (q.pos+v.len) mod q.s.len
   inc(q.filled, nvLen+32)
-  assert q.filled <= q.s.len
+  doAssert q.filled <= q.s.len
 
-proc resize*(q: var DynHeaders, strsize: Natural) {.inline.} =
+proc setLen*(q: var DynHeaders, strsize: Natural) {.inline.} =
   ## Resize the total headers max length.
   ## Evicts entries that don't fit anymore.
   ## Set to ``0`` to clear the queue.
-  q.minResize = min(q.minResize, strsize)
-  q.finalResize = strsize
+  q.minSetLen = min(q.minSetLen, strsize)
+  q.finalSetLen = strsize
   q.s.setLen(strsize)
   while strsize < q.filled:
     discard q.pop()
 
 iterator items*(q: DynHeaders): HBounds {.inline.} =
-  ## Yield headers in FIFO order
-  var i = 0
-  let head = q.tail+q.len-1
-  while i < q.len:
-    yield q.b[(head-i) and (q.b.len-1)]
-    inc i
+  for b in q.bounds:
+    yield b
 
 iterator pairs*(q: DynHeaders): (int, HBounds) {.inline.} =
-  ## Yield headers in FIFO order
-  var i = 0
-  let head = q.tail+q.len-1
-  while i < q.len:
-    yield (i, q.b[(head-i) and (q.b.len-1)])
-    inc i
+  for i, b in pairs q.bounds:
+    yield (i, b)
 
 proc substr*(q: DynHeaders, s: var string, hb: HBounds) {.inline.} =
   ## Append a header name and value to ``s``
@@ -198,9 +171,10 @@ proc `$`*(q: DynHeaders): string {.inline.} =
     result.add("\r\L")
 
 proc cmp*(
-    q: DynHeaders,
-    b: Slice[int],
-    s: openArray[char]): bool {.inline.} =
+  q: DynHeaders,
+  b: Slice[int],
+  s: openArray[char]
+): bool {.inline.} =
   ## Efficiently compare a header name
   ## or value against a string
   if b.len != s.len:
@@ -212,25 +186,25 @@ proc cmp*(
     #s.toOpenArray(0, mLen-1) == q.s.toOpenArray(b.a, b.a+mLen-1) and
     #s.toOpenArray(mLen, b.len-1) == q.s.toOpenArray(0, b.len-mLen-1)
 
-func minResize*(q: DynHeaders): int =
-  q.minResize
+func minSetLen*(q: DynHeaders): int =
+  q.minSetLen
 
-func finalResize*(q: DynHeaders): int =
-  q.finalResize
+func finalSetLen*(q: DynHeaders): int =
+  q.finalSetLen
 
 func hasResized*(dh: DynHeaders): bool =
   result =
-    dh.initialSize != dh.minResize or
-    dh.minResize != dh.finalResize
+    dh.initialSize != dh.minSetLen or
+    dh.minSetLen != dh.finalSetLen
 
 func clearLastResize*(q: var DynHeaders) =
-  q.minResize = q.finalResize
-  q.initialSize = q.finalResize
+  q.minSetLen = q.finalSetLen
+  q.initialSize = q.finalSetLen
 
 when isMainModule:
   block:
     echo "Test DynHeaders"
-    var dh = initDynHeaders(256, 16)
+    var dh = initDynHeaders(256)
     dh.add("cache-control", "private")
     dh.add("date", "Mon, 21 Oct 2013 20:13:21 GMT")
     dh.add("location", "https://www.example.com")
@@ -251,7 +225,7 @@ when isMainModule:
       "date: Mon, 21 Oct 2013 20:13:22 GMT\r\L")
   block:
     echo "Test DynHeaders filled"
-    var dh = initDynHeaders(256, 16)
+    var dh = initDynHeaders(256)
     dh.add("foo", "bar")
     doAssert dh.filled == "foobar".len+32
     doAssert dh.pop() == initHBounds(
@@ -259,7 +233,7 @@ when isMainModule:
       "foo".len .. "foobar".len-1)
     doAssert dh.filled == 0
   block:
-    var dh = initDynHeaders(256, 16)
+    var dh = initDynHeaders(256)
     var s = newString(256-32)
     for i in 0 .. s.len-1:
       s[i] = 'a'
@@ -271,7 +245,7 @@ when isMainModule:
     dh.add("a", "bc")
     doAssert dh.filled == "abc".len+32
   block:
-    var dh = initDynHeaders(256, 16)
+    var dh = initDynHeaders(256)
     dh.add("a", "bc")
     dh.add("a", "bc")
     doAssert dh.filled == ("abc".len+32)*2
@@ -281,21 +255,20 @@ when isMainModule:
     doAssert dh.filled == 0
   block:
     echo "Test DynHeaders length"
-    var dh = initDynHeaders(1024, 4)
+    var dh = initDynHeaders(1024)
     dh.add("foo", "bar")
-    doAssert dh.length == 1
+    doAssert dh.len == 1
     discard dh.pop()
-    doAssert dh.length == 0
+    doAssert dh.len == 0
     for _ in 0 ..< 4:
       dh.add("a", "bc")
-    doAssert dh.length == 4
-    dh.add("a", "bc")
-    doAssert dh.length == 4
+    doAssert dh.len == 4
     for _ in 0 ..< 4:
       discard dh.pop()
+    doAssert dh.len == 0
   block:
     echo "Test DynHeaders strsize"
-    var dh = initDynHeaders(76, 8)
+    var dh = initDynHeaders(76)
     dh.add("asd", "asd")
     doAssert dh.filled == 38
     dh.add("qwe", "qwe")
@@ -318,17 +291,19 @@ when isMainModule:
     doAssert res == "qweqwe"
   block:
     echo "Test DynHeaders resize"
-    var dh = initDynHeaders(256, 16)
+    var dh = initDynHeaders(256)
     dh.add("asd", "asd")
     dh.add("qwe", "qwe")
     dh.add("zxc", "zxc")
     doAssert dh.len == 3
-    dh.resize(100)
+    dh.setLen(100)
     doAssert dh.len == 2
     doAssert $dh ==
       "zxc: zxc\r\L" &
       "qwe: qwe\r\L"
-    dh.resize(0)
+    dh.setLen(0)
     doAssert dh.len == 0
-    dh.resize(256)
+    dh.add("zxc", "zxc")
+    doAssert dh.len == 0
+    dh.setLen(256)
     doAssert dh.len == 0

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -53,7 +53,7 @@ suite "Decoder - Test Header Field Representation Examples":
         0x2d6b, 0x6579, 0x0d63, 0x7573,
         0x746f, 0x6d2d, 0x6865, 0x6164, 0x6572].toBytes
       d = initDecodedStr()
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
     check hdecode(ic, dh, d) == ic.len
     var i = 0
     for h in d:
@@ -70,7 +70,7 @@ suite "Decoder - Test Header Field Representation Examples":
         0x040c'u16, 0x2f73, 0x616d,
         0x706c, 0x652f, 0x7061, 0x7468].toBytes
       d = initDecodedStr()
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
     check hdecode(ic, dh, d) == ic.len
     var i = 0
     for h in d:
@@ -87,7 +87,7 @@ suite "Decoder - Test Header Field Representation Examples":
     ic.add(byte 0x74'u8)
     var
       d = initDecodedStr()
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
     check hdecode(ic, dh, d) == ic.len
     var i = 0
     for h in d:
@@ -101,7 +101,7 @@ suite "Decoder - Test Header Field Representation Examples":
     var
       ic = @[byte 0x82'u8]
       d = initDecodedStr()
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
     check hdecode(ic, dh, d) == ic.len
     var i = 0
     for h in d:
@@ -112,7 +112,7 @@ suite "Decoder - Test Header Field Representation Examples":
     check dh.len == 0
 
 suite "Decoder - Request Examples without Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Request":
     var
@@ -189,7 +189,7 @@ suite "Decoder - Request Examples without Huffman Coding":
       ":authority: www.example.com\r\L"
 
 suite "Decoder - Request Examples with Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Request":
     var ic = @[
@@ -264,7 +264,7 @@ suite "Decoder - Request Examples with Huffman Coding":
       ":authority: www.example.com\r\L"
 
 suite "Decoder - Response Examples without Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Response":
     var
@@ -362,7 +362,7 @@ suite "Decoder - Response Examples without Huffman Coding":
       "date: Mon, 21 Oct 2013 20:13:22 GMT\r\L"
 
 suite "Decoder - Response Examples with Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Response":
     var
@@ -458,7 +458,7 @@ suite "Decoder - Response Examples with Huffman Coding":
 suite "Encoder - Header Field Representation Examples":
   test "Literal Header Field with Indexing":
     var
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
       ic = newSeq[byte]()
       expected = @[
         0x400a'u16, 0x6375, 0x7374, 0x6f6d,
@@ -471,7 +471,7 @@ suite "Encoder - Header Field Representation Examples":
 
   test "Literal Header Field without Indexing":
     var
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
       ic = newSeq[byte]()
       expected = @[
         0x040c'u16, 0x2f73, 0x616d,
@@ -484,7 +484,7 @@ suite "Encoder - Header Field Representation Examples":
 
   test "Literal Header Field Never Indexed":
     var
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
       ic = newSeq[byte]()
       expected = @[
         0x1008'u16, 0x7061, 0x7373, 0x776f,
@@ -498,7 +498,7 @@ suite "Encoder - Header Field Representation Examples":
 
   test "Indexed Header Field":
     var
-      dh = initDynHeaders(256, 16)
+      dh = initDynHeaders(256)
       ic = newSeq[byte]()
       expected = @[byte 0x82'u8]
     doAssert hencode(
@@ -508,7 +508,7 @@ suite "Encoder - Header Field Representation Examples":
     doAssert dh.len == 0
 
 suite "Encoder - Request Examples without Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Request":
     var
@@ -574,7 +574,7 @@ suite "Encoder - Request Examples without Huffman Coding":
       ":authority: www.example.com\r\L"
 
 suite "Encoder - Request Examples with Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Request":
     var
@@ -635,7 +635,7 @@ suite "Encoder - Request Examples with Huffman Coding":
       ":authority: www.example.com\r\L"
 
 suite "Encoder - Response Examples without Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Response":
     var
@@ -718,7 +718,7 @@ suite "Encoder - Response Examples without Huffman Coding":
       "date: Mon, 21 Oct 2013 20:13:22 GMT\r\L"
 
 suite "Encoder - Response Examples with Huffman Coding":
-  var dh = initDynHeaders(256, 16)
+  var dh = initDynHeaders(256)
 
   test "First Response":
     var
@@ -799,17 +799,17 @@ suite "Encoder - Response Examples with Huffman Coding":
 
 suite "Uncategorized tests":
   test "Empty header value":
-    var dh = initDynHeaders(4096, 16)
+    var dh = initDynHeaders(4096)
     var ic = newSeq[byte]()
     hencode("pragma", "", dh, ic, huffman = false)
     var d = initDecodedStr()
     dh.reset()
     hdecodeAll(ic, dh, d)
-    check $d == "pragma: \r\L"
-    check $dh == "pragma: \r\L"
+    check $d == "pragma: \r\n"
+    check $dh == "pragma: \r\n"
 
   test "Empty header value huffman":
-    var dh = initDynHeaders(4096, 16)
+    var dh = initDynHeaders(4096)
     var ic = newSeq[byte]()
     hencode("pragma", "", dh, ic, huffman = true)
     var d = initDecodedStr()
@@ -823,7 +823,7 @@ suite "Uncategorized tests":
     check signalDynTableSizeUpdate(ic, 256) == 3
     check ic.len == 3
     var d = initDecodedStr()
-    var dh = initDynHeaders(4096, 1024)
+    var dh = initDynHeaders(4096)
     var dhSize = 0
     hdecodeAll(ic, dh, d, dhSize)
     check dhSize == 256


### PR DESCRIPTION
- API to signal table size updates done on the dynamic table per resize.
- Remove the number of headers limit. It's not in the spec.

- [x] tests